### PR TITLE
Create lowhealth.asm

### DIFF
--- a/src/sm/lowhealth.asm
+++ b/src/sm/lowhealth.asm
@@ -1,0 +1,7 @@
+
+org $D0EA85
+base $90EA85
+
+; We are changing the health check so the "low health" alarm is never set, and therefore will not play.
+; This is effectively a one-byte change.
+RTS

--- a/src/sm/lowhealth.asm
+++ b/src/sm/lowhealth.asm
@@ -5,3 +5,10 @@ base $90EA85
 ; We are changing the health check so the "low health" alarm is never set, and therefore will not play.
 ; This is effectively a one-byte change.
 RTS
+
+org $D1E6D5
+base $91E6D5
+
+; We have to change the check that unpausing the menu does as well, or else the alarm will trigger and never cease playing until
+; conditions are satisfied when exiting the menu
+RTS


### PR DESCRIPTION
When v30 is released, the website can add an option for the Super Metroid low health alarm, similar to LttP's low health alarm.