### PR TITLE
Remove bomb blocks during MB escape.

### DIFF
--- a/src/main.asm
+++ b/src/main.asm
@@ -9,7 +9,7 @@ incsrc "common.asm"                         ; Common routines
 incsrc "credits.asm"                        ; Common credits scroller
 incsrc "spc_play.asm"                       ; Common SPC player
 
-; --- Super Metroid code ---            
+; --- Super Metroid code ---
 incsrc "sm/hirom.asm"                       ; Super Metroid ExHiROM patch
 incsrc "sm/transition.asm"                  ; Super Metroid Transition patch
 incsrc "sm/teleport.asm"                    ; Super Metroid Teleport patch
@@ -18,6 +18,7 @@ incsrc "sm/items.asm"                       ; Super Metroid ALTTP Items patch
 incsrc "sm/ending.asm"                      ; Super Metroid Ending conditions
 incsrc "sm/newgame.asm"                     ; Super Metroid New Game Initialization
 incsrc "sm/nofanfare.asm"                   ; Super Metroid Remove Item fanfares
+incsrc "sm/minorfixes.asm"                  ; Super Metroid some softlock removals etc
 
 ; --- ALTTP code ---
 incsrc "z3/hirom.asm"	                    ; ALTTP ExHiROM patch

--- a/src/sm/minorfixes.asm
+++ b/src/sm/minorfixes.asm
@@ -1,0 +1,32 @@
+;Fix for escape bomb block softlock by Capn
+;Hijack the door ASM
+org $cfe4cf
+base $8fe4cf
+	jsr NewShaftDoorASM
+	rts
+
+;Free space at ec00
+org $cfec00
+base $8fec00
+NewShaftDoorASM:
+	;Start with Original ASM functions
+	php
+	%a8()
+	lda #$01
+	sta $7ecd38
+	lda #$00
+	sta $7ecd39
+	;Set all blocks in RAM to air
+	;Got lucky here that asm code is done after tile loading ^_^
+	%a16()
+	lda #$00ff
+	sta $7f3262
+	sta $7f3264
+	sta $7f32c2
+	sta $7f32c4
+	sta $7f3322
+	sta $7f3324
+	sta $7f3382
+	sta $7f3384
+	plp
+	rts


### PR DESCRIPTION
Added a new file for minor fixes like the one this commit focuses on. The new sub for the door ASM just changes the bomb blocks into air blocks directly in the RAM after the tile data is loaded. Or something; I'm not sure I entirely know what I'm doing; but this seems to work!