### PR TITLE
Double the number of names for the seed display

### DIFF
--- a/src/sm/randomizer/seed_display.asm
+++ b/src/sm/randomizer/seed_display.asm
@@ -1,17 +1,17 @@
 org $c2ecbb
 base $82ecbb
-	jsr seed_display
+    jsr seed_display
 
 org $c2f800
 base $82f800
 seed_display:
-	pha
-	phx
+    pha
+    phx
     php
     rep #$30
 
     lda.l $420000
-    and #$003f
+    and #$007f
     asl
     asl
     asl
@@ -33,7 +33,7 @@ seed_display:
     bne -
 
     lda.l $420001
-    and #$003f
+    and #$007f
     asl
     asl
     asl
@@ -55,7 +55,7 @@ seed_display:
     bne -
 
     lda.l $420002
-    and #$003f
+    and #$007f
     asl
     asl
     asl
@@ -77,7 +77,7 @@ seed_display:
     bne -
 
     lda.l $420003
-    and #$003f
+    and #$007f
     asl
     asl
     asl
@@ -97,37 +97,30 @@ seed_display:
     iny
     cpx #$000E
     bne -
-    
+
     plp
-	plx
-	pla
+    plx
+    pla
     ldx #$07fe
-	rts
+    rts
 
 CharTable:
-	; 0x00																				  	     0x0F
-	dw $000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f
-	; 0x10																				  	     0x0F
-	dw $000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f
-	; 0x20																				  	     0x0F
-	dw $000f,$0084,$002d,$000f,$000f,$000f,$000f,$0022,$008a,$008b,$000f,$0086,$0089,$0087,$0088,$000f
+    ; 0x00                                                                                       0x0F
+    dw $000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f
+    ; 0x10                                                                                       0x0F
+    dw $000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f,$000f
+    ; 0x20                                                                                       0x0F
+    dw $000f,$0084,$002d,$000f,$000f,$000f,$000f,$0022,$008a,$008b,$000f,$0086,$0089,$0087,$0088,$000f
 NumTable:
-	; 0x30																				  	     0x0F
-	dw $0060,$0061,$0062,$0063,$0064,$0065,$0066,$0067,$0068,$0069,$000f,$000f,$000f,$000f,$000f,$0085
-	; 0x40																				  	     0x0F
-	dw $000f,$006a,$006b,$006c,$006d,$006e,$006f,$0070,$0071,$0072,$0073,$0074,$0075,$0076,$0077,$0078
-	; 0x50																				  	     0x0F
-	dw $0079,$007a,$007b,$007c,$007d,$007e,$007f,$0080,$0081,$0082,$0083,$000f,$000f,$000f,$000f,$000f
-
-
-
-
-
-
-
+    ; 0x30                                                                                       0x0F
+    dw $0060,$0061,$0062,$0063,$0064,$0065,$0066,$0067,$0068,$0069,$000f,$000f,$000f,$000f,$000f,$0085
+    ; 0x40                                                                                       0x0F
+    dw $000f,$006a,$006b,$006c,$006d,$006e,$006f,$0070,$0071,$0072,$0073,$0074,$0075,$0076,$0077,$0078
+    ; 0x50                                                                                       0x0F
+    dw $0079,$007a,$007b,$007c,$007d,$007e,$007f,$0080,$0081,$0082,$0083,$000f,$000f,$000f,$000f,$000f
 
 WordTable:
-    db "GEEMER  "
+    db "GEEMER  "   ; $00
     db "RIPPER  "
     db "ATOMIC  "
     db "POWAMP  "
@@ -135,7 +128,7 @@ WordTable:
     db "NAMIHE  "
     db "PUROMI  "
     db "ALCOON  "
-    db "BEETOM  "
+    db "BEETOM  "   ; $08
     db "OWTCH   "
     db "ZEBBO   "
     db "ZEELA   "
@@ -143,7 +136,7 @@ WordTable:
     db "VIOLA   "
     db "WAVER   "
     db "RINKA   "
-    db "BOYON   "
+    db "BOYON   "   ; $10
     db "CHOOT   "
     db "KAGO    "
     db "SKREE   "
@@ -151,7 +144,7 @@ WordTable:
     db "EVIR    "
     db "TATORI  "
     db "OUM     "
-    db "PUYO    "
+    db "PUYO    "   ; $18
     db "YARD    "
     db "ZOA     "
     db "FUNE    "
@@ -159,7 +152,7 @@ WordTable:
     db "GERUTA  "
     db "SOVA    "
     db "BULL    "
-    db "ARRGI   "
+    db "ARRGI   "   ; $20
     db "BABUSU  "
     db "BORU    "
     db "HACHI   "
@@ -167,7 +160,7 @@ WordTable:
     db "TAINON  "
     db "GERUDO  "
     db "GIBO    "
-    db "KOPPI   "
+    db "KOPPI   "   ; $28
     db "PON     "
     db "HOBA    "
     db "HYU     "
@@ -175,7 +168,7 @@ WordTable:
     db "KYUNE   "
     db "RIBA    "
     db "MEDUSA  "
-    db "TERU    "
+    db "TERU    "   ; $30
     db "FANGIN  "
     db "PIKKU   "
     db "POPO    "
@@ -183,7 +176,7 @@ WordTable:
     db "GUZU    "
     db "AIGORU  "
     db "ROPA    "
-    db "GAPURA  "
+    db "GAPURA  "   ; $38
     db "HEISHI  "
     db "SUTARU  "
     db "TOZOKU  "
@@ -191,3 +184,67 @@ WordTable:
     db "WAINDA  "
     db "KURIPI  "
     db "ZORA    "
+    db "SPAZER  "   ; $40 - START OF LENO ADDITIONS, these are generics that are across almost all games of both universes -
+    db "PLASMA  "
+    db "CHOZO   "
+    db "TORIZO  "
+    db "GOHMA   "
+    db "DAMPE   "
+    db "POE     "
+    db "GANON   "
+    db "PEAHAT  "   ; $48
+    db "RIDLEY  "
+    db "KRAID   "
+    db "SR388   "   ; - Metroid II/Samus Returns, Zero Mission, and Fusion enemies, characters, and bosses
+    db "GUNZOO  "
+    db "SHIRK   "
+    db "MUMBO   "
+    db "SKORP   "
+    db "DRIVEL  "   ; $50
+    db "SERRIS  "
+    db "GERON   "
+    db "FUSION  "
+    db "MAJORA  "   ; - Ocarina of Time/Majora's Mask enemies, characters, and bosses
+    db "GORON   "
+    db "ODOLWA  "
+    db "GOHT    "
+    db "GYORG   "   ; $58
+    db "MORPHA  "
+    db "ONOX    "   ; - Link's Awakening, Oracles of Seasons/Ages enemies, characters, and bosses  - 90
+    db "VERAN   "
+    db "HINOX   "
+    db "ROVER   "
+    db "OMUAI   "
+    db "SYGER   "
+    db "SMOG    "   ; $60
+    db "MINISH  "   ; - Minish Cap enemies, characters, and bosses
+    db "PICORI  "
+    db "MAZURA  "   ; - Zelda 2: Adventure of Link enemies, characters, and bosses
+    db "CAROCK  "
+    db "BARBA   "
+    db "GOOMA   "
+    db "ERROR   "
+    db "DAIRA   "   ; $68
+    db "DEELER  "
+    db "BOON    "
+    db "PHAZON  "   ; - Metroid Prime Trilogy enemies, characters, and bosses
+    db "REZBIT  "
+    db "CHYKKA  "
+    db "AGON    "
+    db "PRIME   "
+    db "ING     "   ; $70
+    db "TALLON  "
+    db "EYON    "
+    db "JELZAP  "
+    db "OCULUS  "
+    db "BLOGG   "
+    db "KRALEE  "
+    db "QUAD    "
+    db "SPORB   "   ; $78
+    db "BRYYO   "
+    db "GELBUG  "
+    db "RUNDAS  "
+    db "KORBA   "
+    db "PHAAZE  "
+    db "ELYSIA  "
+    db "NORION  "   ; $7F


### PR DESCRIPTION
With this we bring in names from the zelda universe as well, since it's combo. The 7 least significant bits of the four first bytes of the RNG block are now used, up from 6 previously.