### PR TITLE
Correct a pose triggered by turning under water physics

### DIFF
--- a/src/sm/config.asm
+++ b/src/sm/config.asm
@@ -1,10 +1,1 @@
-; Super Metroid Randomizer Configuration Flags
-
-org $F4F500
-base $B4F500
-
-; Use the new screw attack animations if enabled
-config_screwattack: ; $B4F500
-    dw #$0000
-
-
+; General Super Metroid randomizer configuration flags

--- a/src/sm/sprite/config.asm
+++ b/src/sm/sprite/config.asm
@@ -1,0 +1,8 @@
+; Sprite specific configuration flags
+
+org $DB93FE
+base $9B93FE
+
+; Use the new screw attack animations if enabled
+config_screw_attack:
+    dw #$0000

--- a/src/sm/sprite/gunport.asm
+++ b/src/sm/sprite/gunport.asm
@@ -5,11 +5,11 @@
 ; memory since Deerforce were very wasteful in this section.
 
 ; $90:C7A5 has pointers to the gun port DMA locations. The now free space at
-; $90:86A3-87BC will be used for a table to DMA sets for all ten directions.
+; $90:86AF-87BC will be used for a table to DMA sets for all ten directions.
 
 gun_port_dma = $9A9A00
 
-org $D086A3
+org $D086AF
 
 gun_port_table:
 

--- a/src/sm/sprite/sprite.asm
+++ b/src/sm/sprite/sprite.asm
@@ -5,6 +5,8 @@
 ; - https://github.com/Artheau/SpriteSomething/blob/v1.0.659/source/metroid3/rom.py
 ; - https://github.com/Artheau/SpriteSomething/blob/v1.0.659/source/metroid3/samus/rom_export.py
 
+incsrc "config.asm"
+
 incsrc "bugfixes.asm"
 incsrc "improvements.asm"
 


### PR DESCRIPTION
With Screw attack, or Screw attack and Space jump equipped, trying to turn under the effect of water physics (in or into water without Gravity equipped) would trigger a static frame from the Space jump spin animation. This commit fixes this and makes the following changes of importance:

- The gun port table is moved and starts at $90:86AF .
- The address for the screw attack behavior flag is moved to $9B:93FE
  - Since this is at the end of space for the former vanilla death animation poses, the flag is now specified in src/sm/sprite/config.asm rather than src/sm/config.asm .
  - Given that this is in the same bank as of one of the routines, we explicitly use the `LDA.l` opcode to make sure the long version is used.
- The long version of `LDA` and `STA` opcodes are also used for timing neutrality between branches that pertain to the effect of the screw attack flag.