### PR TITLE
Preserve accumulator register in sm_save_hook

### DIFF
--- a/src/sm/transition.asm
+++ b/src/sm/transition.asm
@@ -195,7 +195,7 @@ sm_fix_checksum:
     rtl
 
 sm_save_hook:
-    phb : phx : phy
+    phb : phx : phy : pha
     pea $7e00
     plb
     plb
@@ -204,6 +204,7 @@ sm_save_hook:
     jsl sm_save_alttp_items
     jsl stats_save_sram
     jsl mw_save_sram
+    pla
     jml $81800b
 
 sm_save_done_hook:


### PR DESCRIPTION
The accumulator is supposed to contain the requested save slot and
we really shouldn't be trashing that.

I overlooked this detail when I added the saving flag for soft-reset protection in Commit 4e307e8535f598e0171441aae4d8e8c7c5cf0ab2 . The accumulator value is getting replaced with $0001 and the save routine is always saving to the second slot.