### PR TITLE
Restore LN refill and move ALTTP portal into it.

### DIFF
--- a/banks.txt
+++ b/banks.txt
@@ -37,6 +37,7 @@ Bank            Mirror banks    Content
 82:F800-FEFF    C2              -- SM Seed display code --
 82:FF00-FFFF    C2              -- SM Menu Code --
 83:8000-AD6F    C3              SM Bank #83 - Doors
+83:AC00-AC7F    C3              -- New LN Refill Exit (Teleport) Door Data --
 84:8000-EFDF    C4              SM Bank #84 - PLMs
 84:EFE0-FFFF    C4              -- SM PLM's for ALTTP Items --
 85:8000-964F    C5              SM Bank #85
@@ -57,6 +58,7 @@ Bank            Mirror banks    Content
 8F:EA00-EAFF    CF              -- SM Golden 4 Skip --
 8F:EB00-EBFF    CF              -- SM Wake Zebes --
 8F:EC00-ECFF    CF              -- SM Escape Climb fix --
+8F:ED00-EDFF    CF              -- New LN Refill Room Header --
 90:8000-F63F    D0              SM Bank #90
 91:8000-FFFF    D1              SM Bank #91
 92:8000-EDFF    D2              SM Bank #92

--- a/src/sm/minorfixes.asm
+++ b/src/sm/minorfixes.asm
@@ -34,3 +34,37 @@ NewShaftDoorASM:
 	sta $7f3384
 	plp
 	rts
+
+
+; Create a new refill room with two doors to be used instead of the regular LN refill room
+; so that the right door can lead to an ALTTP portal and still preserve the refill room
+
+org $cfed00
+NewLNRefillRoom:
+; Room $ED00: Header
+.header
+	db $39, $02, $15, $0F, $01, $01, $70, $A0, $00 
+	dw .doors, $E5E6
+
+.state
+; Room $ED00: Default State
+	dl $CE8FA6 
+	db $17, $00, $03
+	dw $87BA, $A623, $8777, $0000, $0000, $0000, $0000, $8D9C, $0000, $91F7
+
+.doors
+; Room $ED00: Door list
+    dw $98A6 				; Back to Screw attack room
+	dw NewLNRefillDoorData_exit 	; New door leading out to ALTTP
+	
+org $c3ac00
+NewLNRefillDoorData:
+; New door table data for the added door
+.exit
+	dw $AFFB : db $00, $04, $01, $06, $00, $00 : dw $8000, $0000
+.entry
+	dw NewLNRefillRoom : db $00, $05, $0E, $06, $00, $00 : dw $8000, $0000
+
+; Repoint screw attack door into the new room
+org $c39a7a
+	dw NewLNRefillRoom

--- a/src/sm/teleport.asm
+++ b/src/sm/teleport.asm
@@ -90,7 +90,7 @@ sm_teleport_table:
         db $f2, $ff
 
     ; LN GT refill -> Misery mire right side fairy              98a6
-    dw $9a7a, $0115, $0040 
+    dw NewLNRefillDoorData_exit, $0115, $0040 
         db $70, $00, $16, $01, $64, $0c, $36, $01, $c7, $0c, $b8, $01, $70, $00, $26, $03          
         db $d3, $0c, $c1, $01, $00, $0c, $1e, $0f, $00, $00, $00, $03, $20, $0b, $00, $10
         db $00, $ff, $00, $04, $00, $21, $42, $16, $00, $00, $0a, $00, $f6, $ff, $fa, $ff

--- a/src/z3/teleport.asm
+++ b/src/z3/teleport.asm
@@ -96,5 +96,5 @@ zelda_teleport_table:
     dw $0122, $8bce, $0035  ; Links house -> Parlor (from Crateria Map station)
     dw $00e5, $97c2, $0003  ; Death mountain cave -> Norfair map station
     dw $010e, $a894, $0077  ; Dark world ice rod cave -> Maridia missile refill
-    dw $0115, $98a6, $0070  ; Misery mire right side -> LN GT Refill
+    dw $0115, NewLNRefillDoorData_entry, $0070  ; Misery mire right side -> LN GT Refill
     dw $0000


### PR DESCRIPTION
This adds back the Lower Norfair health refill room where the portal to Misery Mire previously was located.
That portal is now moved inside the refill room as a new door exiting the refill room to the right.

Doing this restores the layout closer to vanilla SM and makes things like suitless LN a bit more viable.