### PR TITLE
Add safeguards for fairy pond boomerang/shield/bow upgrades

### DIFF
--- a/src/z3/randomizer/tables.asm
+++ b/src/z3/randomizer/tables.asm
@@ -671,6 +671,16 @@ db #$FF ; no substitution
 ;OldHauntedGroveItem:
 ;	db #$14 ; #$14 = Flute
 ;--------------------------------------------------------------------------------
+org $06C8DB ; PC $348DB
+FairyBoomerang:
+	db #$2A ; Trigger on red boomerang
+org $06C8EB ; PC $348EB
+FairyShield:
+	db #$05 ; Trigger on red shield
+org $06C910 ; PC $34910
+FairyBow:
+	db #$3B ; Trigger on bow with silver arrows
+;--------------------------------------------------------------------------------
 ;2B:Bottle Already Filled w/ Red Potion
 ;2C:Bottle Already Filled w/ Green Potion
 ;2D:Bottle Already Filled w/ Blue Potion


### PR DESCRIPTION
The items that trigger the upgrades are changed such that:
- Red Boomerang trigger in order to give back Red Boomerang
- Red Shield trigger in order to give back Red Shield
- Bow with Silver arrows trigger in order to give back Bow with Silver arrows

The upgraded item were chosen over having the initial item (Blue Boomerang, Blue Shield, Bow with normal arrows) give itself because the dialog text speaks of the upgraded item. No change were made to the sword upgrade since the code for this "hides" deeper.