### PR TITLE
Bugfix for "death in LW chest game triggers pyramid respawn"

### DIFF
--- a/src/z3/randomizer/darkworldspawn.asm
+++ b/src/z3/randomizer/darkworldspawn.asm
@@ -47,8 +47,10 @@ RTL
 SetDeathWorldChecked:
 	LDA $1B : BEQ + ; skip this for indoors
 		LDA $040C : CMP #$FF : BNE .done ; unless it's a cave
-
-		LDA $A0 : BNE + : LDA GanonPyramidRespawn : BEQ + ; check if we died in ganon's room and pyramid respawn is enabled
+		; check if we died in ganon's room and pyramid respawn is enabled
+		LDA $A0 : BNE +
+		LDA $A1 : BNE +
+		LDA GanonPyramidRespawn : BEQ +
 			BRA .pyramid
 	+
 JMP DoWorldFix


### PR DESCRIPTION
Branched from master - There's a Z3R bug where if you die in the lost woods chest game room (to bombs, presumably) it triggers the pyramid respawn behavior. This fix is a copy of the one implemented at Z3R for the same issue. It just checks the high byte as well as the low byte when deciding whether to branch.