### PR TITLE
Bugfix for SM keylist showing in non keysanity

### DIFF
--- a/src/sm/keycards.asm
+++ b/src/sm/keycards.asm
@@ -121,7 +121,10 @@ keycard_update_layer3:
     dex #2
     bpl -
 
+    lda config_keysanity
+    beq keycard_maptext_skip
     jsr keycard_draw_maptext
+keycard_maptext_skip:
 
     ldx $0330  
     lda #$0F00


### PR DESCRIPTION
Added a check to skip the drawing of the layer 3 text on the SM map when the game mode is not keysanity.