### PR TITLE
Z3 skip title/file select screens

### DIFF
--- a/src/main.asm
+++ b/src/main.asm
@@ -41,3 +41,4 @@ incsrc "z3/items.asm"                       ; ALTTP Super Metroid Items
 incsrc "z3/ending.asm"                      ; ALTTP Ending Conditions
 incsrc "z3/newgame.asm"                     ; ALTTP New Game Initialization
 incsrc "z3/multiworld.asm"                  ; ALTTP Multiworld support features
+incsrc "z3/skiptitle.asm"                   ; ALTTP Skip Title Screen and File Select Screen

--- a/src/z3/skiptitle.asm
+++ b/src/z3/skiptitle.asm
@@ -1,0 +1,16 @@
+; Title screen entry point: $0C:C100
+; jump directly to $C2B6 for file select menu
+org $0cc100
+jmp $c2b6
+
+; This is an address in a jump table that stumbles 
+; through a bunch of drawing and animation for the file
+; select screen. This just copies the last address to
+; the first index, so it doesn't bother with any of the
+; presentation and just jumps straight to the logic.
+org $0ccc7a
+dl $0CCDC6
+
+; file select screen
+org $0cce2a
+jmp $ce5c ; jump straight to "action" button handler, loading the save


### PR DESCRIPTION
This patch causes Z3 to bypass the title screen and file select screen, so that saving and quitting brings you quickly to the respawn select (or pyramid) without allowing a chance to fiddle with the Z3 save files.

Please look it over when you have time and discuss whether this is a good way to solve the issue. I did this mainly as an exercise, so if you want to deal with the save issue differently then go ahead and close this.