### PR TITLE
SM title screen - remove extra save slots

### DIFF
--- a/src/sm/titlescreen.asm
+++ b/src/sm/titlescreen.asm
@@ -77,3 +77,122 @@ titlescreen_upload_gfx:
     PLP
     LDA #$02 : STA $420B  ; start DMA transfer, the code we wrote over
     RTL
+
+
+; This is the index of the cursor on the file select screen.
+; 0 is the first save slot, 4 is "clear data", 5 is "exit"
+!smFileSelectCursorIndex = $0952
+; This is a bitfield indictating which save slots hold data.
+; The LSB represents the first slot.
+!smSaveFilePresenceBits = $0954
+
+; SM file select screen: up button handler
+org  $c1a25e
+base $81a25e
+{
+  ; if cursor is at index 0 then set it to 5
+  lda !smFileSelectCursorIndex
+  bne +
+  lda #$0005
+  bra smFileSelectControllerHackDone
+  
++ ; if cursor is at index 4 then set it to 0
+  cmp #$0004
+  bne +
+  lda #$0000
+  bra smFileSelectControllerHackDone
+  
++ ; cursor is at index 5, so if a save is present
+  ; then go to 4, otherwise go to 0
+  lda !smSaveFilePresenceBits
+  asl a ; since only the first slot can hold data, we can 
+  asl a ; just mul by 4 to get the desired index value
+  bra smFileSelectControllerHackDone
+}
+
+; SM file select screen: down button handler
+org  $c1a286
+base $81a286
+{
+  ; if cursor is at index 0 then go to 4 if a save is
+  ; present, otherwise go to 5
+  lda !smFileSelectCursorIndex
+  bne +
+  lda !smSaveFilePresenceBits
+  ; the save bits will be zero if there's a save and 1 if not
+  ; so we can xor that by 5 to get the desired value
+  eor #$0005
+  bra smFileSelectControllerHackDone
+  
++ ; if cursor is at 4 then set it to 5
+  cmp #$0004
+  bne +
+  lda #$0005
+  bra smFileSelectControllerHackDone
+  
++ ; if cursor is at 5 then set it to 0
+  lda #$0000
+  bra smFileSelectControllerHackDone
+}
+
+; At this point the routine copies A into the cursor index
+; memory location and then continues processing the logic
+org  $c1a2af
+base $81a2af
+smFileSelectControllerHackDone:
+
+; This is the point during the scene drawing just before
+; the second save slot is checked and its state drawn.
+; Instead of doing that, we'll skip past the second and
+; third slots. But before jumping we apply the skipped changes
+; to the file presence bits so that they indicate that those
+; slots are empty.
+org  $c19f46
+base $819f46
+sec
+ror !smSaveFilePresenceBits
+ror !smSaveFilePresenceBits
+jmp $9fb2
+
+; This simply skips the rendering of the "DATA COPY" text.
+org  $c19fc6
+base $819fc6
+jmp $9fd2
+
+; This is during the routine for the fade-in substate (3). This is
+; where the second helmet is about ot be drawn. There's no logic past
+; the helmet drawing here, so we can just rts.
+org  $c19dcf
+base $819dcf
+rts
+
+; This is during the primary logic routine (substate 4) for the file
+; select screen. This is just before the second helmet is drawn. We'll
+; jump past the second and third helmets and continue from that point.
+org  $c1a1d2
+base $81a1d2
+jmp $a1de
+
+; This is during the transition from the file select screen to the
+; save config screen (this transition is substate 1F). This skips
+; over drawing the second and third helmets.
+org  $c19d85
+base $819d85
+jmp $9d91
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+


### PR DESCRIPTION
Branched from master.

This alters the SM file select screen such that the second and third save slots, as well as the "DATA COPY" option, are not drawn and are not selectable (cursor skips past them). If applied in conjunction with #44 , this should remove all logical paths for players to cause bugs or exploits by copying or erasing save data.

Note that no modification was required to ensure that the Z3 data is initialized when the SM data is erased. This is because erasing the SM data means that the next save data interaction must necessarily be the creation of a new save, which triggers the Z3 save data initialization.

I'm aware that we're working on a replacement for the scene that this alters, but this patch can serve as a simple bugfix while that work is in progress.