### PR TITLE
Temp light cone glitch fix 2

### DIFF
--- a/src/z3/randomizer/newitems.asm
+++ b/src/z3/randomizer/newitems.asm
@@ -1075,10 +1075,16 @@ EnableTemporaryCone:
 		BEQ +
 		LDA $7EF34A ; Check if we have lamp
 		BNE +
+    
+    REP #$20
 		LDA $7E00A0 
-		CMP #$55  ; Check if we're in secret passage
+		CMP #$0055  ; Check if we're in secret passage
 		BEQ +
-
+    CMP #$0109 ; Check if we're in the potion shop
+    BEQ +      ; (check both bytes or problems will happen in PoD)
+		CMP #$00E4 ; Check if we're in old man's cave (the save location)
+		BEQ +
+    
 		LDA #$01
 		STA $1D		; Enable color math for BG1
 		STA $0458	; Set the "Lamp in dark room flag" temporarily
@@ -1087,8 +1093,8 @@ EnableTemporaryCone:
 		REP #$20    ; Write the scroll positions to the PPU registers
 		LDA $E0 : STA $120 : STA $210D 
 		LDA $E6 : STA $124 : STA $210E
-		SEP #$20
 +
+		SEP #$20
 		RTS
 
 DisableTemporaryCone:

--- a/src/z3/randomizer/newitems.asm
+++ b/src/z3/randomizer/newitems.asm
@@ -1076,13 +1076,13 @@ EnableTemporaryCone:
 		LDA $7EF34A ; Check if we have lamp
 		BNE +
     
-    REP #$20
+		REP #$20
 		LDA $7E00A0 
 		CMP #$0055  ; Check if we're in secret passage
 		BEQ +
-    CMP #$0109 ; Check if we're in the potion shop
-    BEQ +      ; (check both bytes or problems will happen in PoD)
-		CMP #$00E4 ; Check if we're in old man's cave (the save location)
+		CMP #$0109  ; Check if we're in the potion shop
+		BEQ +       ; (check both bytes or problems will happen in PoD)
+		CMP #$00E4  ; Check if we're in old man's cave (the save location)
 		BEQ +
     
 		LDA #$01


### PR DESCRIPTION
Addressing issue [#124](https://github.com/tewtal/SMZ3Randomizer/issues/124#issue-714501243) from the main repo. 

The temporary light cone patch is causing graphical issues in rooms that are marked as dark rooms but aren't actually dark rooms (they seem to all be "dim" rooms, just one or two levels down from full brightness). This quick-fix corrects the issue for potion shop and old man cave, but a better long term solution is called for.

Just off the top of my head, we could find an unused memory byte and have the room loading routine clear it, and the dark room prep routine set it, then we could check that bit instead of $7E:C005, which is giving false positives. That way we don't have to keep finding and adding exceptions.

Alternatively we could just find some other variable to read from in order to determine whether the room is actually a dark room.

Thoughts?

(P.S. - I asked about this on Discord, but how do I make it not put the me-updating-from-the-official-repo commit on things?)