### PR TITLE
fast mother brain

### DIFF
--- a/src/config.asm
+++ b/src/config.asm
@@ -17,3 +17,10 @@ config_sm_sprite:    ; $F47004
 ; Enables keysanity specific code sections.
 config_keysanity:    ; $F47006
     dw #$0000
+
+; starting events
+; 0001 is zebes awake (default)
+; 0400 is Tourian open (AKA Fast MB)
+; 03C0 is G4 statues already grey (no animation)
+config_events:       ; F47008
+    dw #$0001

--- a/src/sm/newgame.asm
+++ b/src/sm/newgame.asm
@@ -43,7 +43,7 @@ introskip_doorflags:
     sta $7ed8b8
 
     ; Set up open mode event bit flags
-    lda #$0001
+    lda.l config_events
     sta $7ed820
     
     lda #$0000


### PR DESCRIPTION

Easy peasy; rather than initializing the event bits to $0001 (Zebes awake), initialize it to include Tourian open as well. The crux of this is done in SMZ3Randomizer, not in the assembly. If this is accepted i'll try to put together an SMZ3Randomizer pull request with some basics on how to use this config section.

There's no "org" statement in src/sm/config.asm, which I think would be a better place to put this config option. I didn't want to find a free location there, so instead I used the existing src/config.asm. If you'd prefer the config_events label elsewhere, just let me know where's better, it's easy to change.