### PR TITLE
Clear MW seed data and re-init on new game

### DIFF
--- a/src/sm/newgame.asm
+++ b/src/sm/newgame.asm
@@ -63,7 +63,20 @@ introskip_doorflags:
     jsl alttp_new_game      ; Setup new game for ALTTP
     jsl sm_copy_alttp_items ; Copy alttp items into temporary SRAM buffer
     jsl zelda_fix_checksum  ; Fix alttp checksum    
-    
+
+    ; Clear multiworld seed data and reinitialize on new game.
+    lda config_multiworld
+    beq +
+    lda #$0000
+    ldx #$0000
+-
+    sta.l !SRAM_MW_SEED_DATA, x
+    inx : inx
+    cpx #$0050
+    bne -
+    jsl mw_init
++
+
     ; begin Leno edits here!
     LDA #$FFFF  ; decrement the accumulator by 1, making it #$FFFF
     sta.l $7ED908  ; activate Crateria and Brinstar maps


### PR DESCRIPTION
This change fixes an issue when deleting your save game data after receiving a bunch of MW items.
Without this, the game thinks it already received all the sent items and they don't get re-sent
if you delete your save and start a new one.  This clears the MW seed data and calls the init
subroutine which will see that the seed data doesn't match and re-initialize everything.
The previously sent items will then get re-sent when you connect again.