### PR TITLE
Reset Bomb Torizo door close to vanilla timing.

### DIFF
--- a/src/sm/randomizer/bomb_torizo.asm
+++ b/src/sm/randomizer/bomb_torizo.asm
@@ -19,4 +19,4 @@ org $c4d33b
 
 ; Door close timer
 org $c4ba54
-    dw $28*2 ; Double vanilla
+    dw $28


### PR DESCRIPTION
Multiple people have gotten inadvertently doorstuck with the extended timer.