### PR TITLE
MSU Fixes and Extended Tracks

### DIFF
--- a/src/credits.asm
+++ b/src/credits.asm
@@ -80,6 +80,14 @@ init:
     ; Start SPC song
     jsl playmusic
 
+    ; If MSU music is previously playing, play the combo credits MSU track
+    sep #$30
+    lda $2002 : cmp.b #'S' : bne +
+        lda #99 : sta $2004 : stz $2005 ; Play track 99
+        lda #1 : sta $2007 ; Sets the track to not repeat
+        lda #$FF : sta $2006 ; Set to max volume
+    + 
+
     ; Load credits fonts and palettes into VRAM/CGRAM
     %ai16()
     jsr load_graphics

--- a/src/sm/msu.asm
+++ b/src/sm/msu.asm
@@ -1,3 +1,49 @@
+; Track List:
+;
+; 1/101 - Apperance fanfare
+; 2/102 - Item acquired (not used in SMZ3)
+; 3/103 - Item/elevator room
+; 4/104 - Opening with intro
+; 5/105 - Opening without intro
+; 6/106 - Crateria - First landing (with thunder)
+; 7/107 - Crateria - First landing (without thunder) (not used in SMZ3)
+; 8/108 - Crateria - Space Pirates Appear
+; 9/109 - Crateria - Golden statues room
+; 10/110 - Theme of Samus Aran (Samus's Ship & East Crateria)
+; 11/111 - Green Brinstar
+; 12/112 - Red Brinstar
+; 13/113 - Upper Norfair
+; 14/114 - Lower Norfair
+; 15/115 - Inner Maridia
+; 16/116 - Outer Maridia
+; 17/117 - Tourian
+; 18/118 - Mother Brain battle
+; 19/119 - Big Boss Battle 1 (Chozo statues, Ridley, and Draygon)
+; 20/120 - Evacuation
+; 21/121 - Chozo statue awakens
+; 22/122 - Big Boss Battle 2 (Crocomire, Kraid, Phantoon, Baby Metroid) 
+; 23/123 - Tension/Hostile Incoming (before Kraid, Phantoon, and Baby Metroid. Played in between Croc segments)
+; 24/124 - Plant miniboss (Sporespawn and Botwoon)
+; 25/125 - Ceres Station (not used in SMZ3)
+; 26/126 - Wrecked Ship Powered Off
+; 27/127 - Wrecked Ship Powered On
+; 28/128 - Theme of Super Metroid (not used in SMZ3)
+; 29/129 - Death cry
+; 30/130 - Ending
+;
+; SM Extended tracks
+;
+; 31/131 - Kraid incoming (falls back to 23/123)
+; 32/132 - Kraid battle (falls back to 22/122)
+; 33/133 - Phantoon incoming (falls back to 23/123)
+; 34/134 - Phantoon battle (falls back to 22/122)
+; 35/135 - Draygon battle (falls back to 19/119)
+; 36/136 - Ridley battle (falls back to 19/119)
+; 37/137 - Baby incoming (falls back to 23/123)
+; 38/138 - The baby (falls back to 22/122)
+; 39/139 - Hyper beam (falls back 10/110)
+; 40/140 - Game over
+
 ;;; MSU memory map I/O
 !MSU_STATUS = $2000
 !MSU_ID = $2002
@@ -78,10 +124,7 @@ SM_MSU_Main:
 +
 
 	;; $04 is usually ambience, call original code
-	cmp.b #$04
-	bne +
-	jmp .OriginalCode
-+
+	cmp.b #$04 : BEQ .PlayAmbience
 
 	;; Check if the song is already playing
 	cmp.w !CurrentMusic
@@ -120,28 +163,100 @@ SM_MSU_Main:
 	;; Load music to play from pointer
 	sep #$20
 	lda ($00),y
-	
+
 	;; Loading $00 means calling the original code
-	beq .OriginalCode
+	bne .PlayMusic
+    jml .OriginalCode
+
+.PlayAmbience
+    PHA
+    LDA.w $0998
+    CMP #$1A : BEQ +
+    PLA
+    JMP .OriginalCode
++
+    PLA
+    LDA #40
+    JML .CheckFallbacks
+
 .PlayMusic
     CMP #10 : BEQ .LoadSamusTheme
-    BRA .CheckFallbacks
+    CMP #19 : BEQ .LoadBossThemeOne
+    CMP #22 : BEQ .LoadBossThemeTwo
+    CMP #23 : BEQ .LoadTensionTheme
+    JML .CheckFallbacks
 
-.LoadSamusTheme
-    TAX
+.LoadSamusTheme ; (10)
     REP #$20
-
-    ; Play no music following the baby draining Samus's health
     LDA $079B
+    LDX #00
+
+    ; Play no music following the baby draining Samus's heath
     CMP #$DCB1 : BNE +
-        SEP #$20
-        TXA
-        BRA .OriginalCode
+        LDX #$FF
+    +
+    ; Play "hyper beam" theme when fighting the last phase of Mother Brain
+    CMP #$DD58 : BNE +
+        LDX #39
     +
 
     SEP #$20
-    TXA
-    bra .CheckFallbacks
+    LDY #10
+    bra .TryExtended
+
+; Boss theme for Ridley, Draygon, and Torizo statues
+.LoadBossThemeOne ; (19)
+    REP #$20
+    LDA $079B
+    LDX #00
+
+    ; Draygon
+    CMP #$DA60 : BNE +
+        LDX #35
+    +
+    ; Ridley
+    CMP #$B32E : BNE +
+        LDX #36
+    +
+
+    SEP #$20
+    LDY #19
+    bra .TryExtended
+
+; Boss theme for Kraid, Crocomire, Phantoon, and the Baby
+.LoadBossThemeTwo ; (22)
+    LDA $079F : TAX
+    LDA BossTwoExtendedThemes,X : TAX
+    LDY #22
+    bra .TryExtended
+
+; Song before fighting some of the bosses
+.LoadTensionTheme ; (23)
+    LDA $079F : TAX
+    LDA TensionExtendedThemes,X : TAX
+    LDY #23
+    bra .TryExtended
+
+; X = Extended Song (00 => Skip to Fallback, FF -> Original Code)
+; Y = Original Song
+.TryExtended
+    CPX #00 : BNE +
+        TYA
+        bra .CheckFallbacks
+    +
+    CPX #$FF : BNE +
+        TYA
+        bra .OriginalCode
+    +
+    
+    phx
+    TXA : DEC : LSR #3 : TAX
+	LDA.l MSUFallbackTable+$10,X : BEQ .FailExtended : CMP.b #$FF : BEQ .continue
+
+.FailExtended
+    PLA
+    TYA
+    BRA .CheckFallbacks
 
 .CheckFallbacks
 	;; Check track fallback list if the track is available
@@ -179,7 +294,7 @@ SM_MSU_Main:
 	- : STA.w APUIO0 : CMP.w APUIO0 : BNE - ; Wait until mute/unmute command is ACK'ed
     - : STZ.w APUIO0 : LDA.w APUIO0 : BNE - ; Wait until mute/unmute command is completed
 	bra .Exit
-	
+
 .fallback
     PLA
     BRA .OriginalCode
@@ -284,6 +399,11 @@ bank_45: ;; Big Boss Battle 2
 bank_48: ;; Samus's Ship (Mother Brain)
 	db 10
 
+BossTwoExtendedThemes:
+db #00,#32,#00,#34,#00,#38 ; Boss theme two
+
+TensionExtendedThemes:
+db #00,#31,#00,#33,#00,#37 ; Boss theme two
 
 TrackNeedLooping:
 ;; Samus Aran's Appearance fanfare

--- a/src/sm/msu.asm
+++ b/src/sm/msu.asm
@@ -114,7 +114,7 @@ SM_MSU_Main:
 	pha
 	plb
 	
-	%CheckMSUPresence(.OriginalCode)
+	%CheckMSUPresence(.Exit)
 	
 	;; Load current requested music
 	lda.w !RequestedMusic

--- a/src/sm/msu.asm
+++ b/src/sm/msu.asm
@@ -149,13 +149,13 @@ SM_MSU_Main:
 	DEC : PHA
 		AND.b #$07 : TAY
 		PLA : LSR #3 : TAX
-	LDA.l MSUFallbackTable+$10,X : BEQ .OriginalCode : CMP.b #$FF : BEQ .continue
+	LDA.l MSUFallbackTable+$10,X : BEQ .fallback : CMP.b #$FF : BEQ .continue
 	
 	- : CPY #$00 : BEQ +
 		LSR : DEY : BRA -
 	+
 	
-	AND.b #$01 : BEQ .OriginalCode
+	AND.b #$01 : BEQ .fallback
 
 	.continue
 	pla
@@ -180,6 +180,10 @@ SM_MSU_Main:
     - : STZ.w APUIO0 : LDA.w APUIO0 : BNE - ; Wait until mute/unmute command is completed
 	bra .Exit
 	
+.fallback
+    PLA
+    BRA .OriginalCode
+
 .OriginalCode
 	lda.b #$00
 	sta.w !MSU_AUDIO_CONTROL

--- a/src/sm/msu.asm
+++ b/src/sm/msu.asm
@@ -124,6 +124,26 @@ SM_MSU_Main:
 	;; Loading $00 means calling the original code
 	beq .OriginalCode
 .PlayMusic
+    CMP #10 : BEQ .LoadSamusTheme
+    BRA .CheckFallbacks
+
+.LoadSamusTheme
+    TAX
+    REP #$20
+
+    ; Play no music following the baby draining Samus's health
+    LDA $079B
+    CMP #$DCB1 : BNE +
+        SEP #$20
+        TXA
+        BRA .OriginalCode
+    +
+
+    SEP #$20
+    TXA
+    bra .CheckFallbacks
+
+.CheckFallbacks
 	;; Check track fallback list if the track is available
 	pha
 	DEC : PHA

--- a/src/sm/transition.asm
+++ b/src/sm/transition.asm
@@ -40,10 +40,6 @@ transition_to_sm:
     lda #$8f
     sta $002100                 ; Enable PPU force blank
 
-    lda.b #$00
-    sta.w $2007
-    sta.w $2006                 ; Kill MSU-1 music if it's playing
-
     jsl sm_spc_reset            ; Kill the ALTTP music engine and put the SPC in IPL upload mode
                                 ; Gotta do this before switching RAM contents
 
@@ -143,6 +139,10 @@ sm_spc_reset:
     lda #$ff                    ; Send N-SPC into "upload mode"
     sta $2140
 
+    lda.b #$00
+    sta.w $2007
+    sta.w $2006                 ; Kill MSU-1 music if it's playing
+    
     lda.b #sm_spc_data            ; Store the location of our "exploit data"
     sta $00                     ; so that the ALTTP music upload routine
     lda.b #sm_spc_data>>8         ; uses it.

--- a/src/spc_play.asm
+++ b/src/spc_play.asm
@@ -92,17 +92,23 @@ loadspc:
 
     ; Copy $02-ef to SPC RAM
     ; sendmusicblock $e0 $c002 $0002 $00ee
-    sep #!A_8BIT
-    lda #$f6    ; 1
-    sta $14
-    rep #!A_8BIT
-    lda #$0002  ; 2
-    sta $12
+    ; Only begin playing if there is no MSU track playing
+    sep #$30
+    lda $2002 : cmp.b #'S' : beq +
+        rep #$30
+        sep #!A_8BIT
+        lda #$f6    ; 1
+        sta $14
+        rep #!A_8BIT
+        lda #$0002  ; 2
+        sta $12
 
+        rep #!XY_8BIT
+        ldx #$0002 ; 3
+        ldy #$00ee ; 4
+        jsr copyblocktospc
+    +
     rep #!XY_8BIT
-    ldx #$0002 ; 3
-    ldy #$00ee ; 4
-    jsr copyblocktospc
 
     ; sendmusicblock $f6 $0100 $0100 $7f00
     sep #!A_8BIT
@@ -118,17 +124,22 @@ loadspc:
     jsr copyblocktospc
 
     ; sendmusicblock $f7 $0000 $8000 $7fc0
-    sep #!A_8BIT
-    lda #$f7 ; 1
-    sta $14
-    rep #!A_8BIT
-    lda #$0000 ; 2
-    sta $12
+    ; Only begin playing if there is no MSU track playing
+    sep #$30
+    lda $2002 : cmp.b #'S' : beq +
+        rep #$30
+        sep #!A_8BIT
+        lda #$f7 ; 1
+        sta $14
+        rep #!A_8BIT
+        lda #$0000 ; 2
+        sta $12
 
-    rep #!XY_8BIT
-    ldx #$8000 ; 3
-    ldy #$7fc0 ; 4
-    jsr copyblocktospc
+        rep #!XY_8BIT
+        ldx #$8000 ; 3
+        ldy #$7fc0 ; 4
+        jsr copyblocktospc
+    +
 
     ; Create SPC init code that sets up registers
     jsr makespcinitcode

--- a/src/z3/randomizer/hooks.asm
+++ b/src/z3/randomizer/hooks.asm
@@ -2187,9 +2187,24 @@ JML.l PreOverworld_LoadProperties_ChooseMusic
 org $028389  ; <- Bank02.asm:763
 PreOverworld_LoadProperties_SetSong:
 ;--------------------------------------------------------------------------------
+; Remove Aga1 check for Kakariko music, always play track 7
+org $02A992 ; (BCS $A999)
+NOP #2
+org $02A9B0 ; (BCS $A9B7)
+NOP #2
+org $02C1C8 ; (BCS $C1CC)
+NOP #2
+org $02ADA0 ; (LDA.b #$F1 : STA $012C)
+JSL Overworld_MosaicDarkWorldChecks : NOP
+;--------------------------------------------------------------------------------
 org $05CC58 ; <- Bank05.asm:1307 (LDA $040A : CMP.b #$18)
-JSL PsychoSolder_MusicCheck
-NOP #1
+JSL PsychoSolder_MusicCheck : NOP #1
+;--------------------------------------------------------------------------------
+org $02B13A ; <- Bank02.asm:7647
+dl Overworld_FinishMirrorWarp
+;--------------------------------------------------------------------------------
+org $0AB949 ; <- Bank0A.asm:270 (Different from US ROM)
+JSL BirdTravel_LoadTargetAreaMusic : NOP #16
 ;================================================================================
 
 ;================================================================================

--- a/src/z3/randomizer/msu.asm
+++ b/src/z3/randomizer/msu.asm
@@ -643,6 +643,10 @@ MSUMain:
 
 .command_f1:
     CPX.b #!VAL_COMMAND_FADE_OUT : BNE .command_f0
+    ; Don't fade out when leaving under the bridge
+    LDA $8A : CMP #$80 : BNE +
+        JML SPCContinue
+    +
     STZ.w TargetVolume
     STZ.w CurrentMSUTrack
     JML SPCContinue

--- a/src/z3/randomizer/msu.asm
+++ b/src/z3/randomizer/msu.asm
@@ -472,9 +472,9 @@ MSUInit:
 .check_sm_fallback
         PHP : SEP #$10
         ;LDA.l NoBGM : BNE .done
-    + : LDA.b #132
-    LDX.b #3
-    LDY.b #7
+    + : LDA.b #142
+    LDX.b #5
+    LDY.b #1
 
 .check_sm_track
     STA.w MSUTRACK

--- a/src/z3/randomizer/music.asm
+++ b/src/z3/randomizer/music.asm
@@ -9,7 +9,7 @@ PreOverworld_LoadProperties_ChooseMusic:
 
     LDX.b #$02 ; Default light world theme
 
-    LDA $8A : ORA #$40 ; check both light and dark world DM at the same time
+    LDA.b OverworldIndex : ORA.b #$40 ; check both light and dark world DM at the same time
     CMP.b #$43 : BEQ .endOfLightWorldChecks
     CMP.b #$45 : BEQ .endOfLightWorldChecks
     CMP.b #$47 : BEQ .endOfLightWorldChecks
@@ -17,61 +17,64 @@ PreOverworld_LoadProperties_ChooseMusic:
     LDY.b #$5A ; Main overworld animated tileset
 
     ; Skip village and lost woods checks if entering dark world or a special area
-    LDA $8A : CMP.b #$40 : !BGE .notVillageOrWoods
+    LDA.b OverworldIndex : CMP.b #$40 : !BGE .notVillageOrWoods
 
     LDX.b #$07 ; Default village theme
 
-    ; Check what phase we're in
-    LDA $7EF3C5 : CMP.b #$03 : !BLT +
-        LDX.b #$02 ; Default light world theme (phase >=3)
-    +
-
     ; Check if we're entering the village
-    LDA $8A : CMP.b #$18 : BEQ .endOfLightWorldChecks
+    LDA.b OverworldIndex : CMP.b #$18 : BEQ .endOfLightWorldChecks
     ; For NA release would we also branch on indexes #$22 #$28 #$29
 
     LDX.b #$05 ; Lost woods theme
 
     ; check if we've pulled from the master sword pedestal
-    LDA $7EF300 : AND.b #$40 : BEQ +
+    LDA.b OverworldEventDataWRAM+$80 : AND.b #$40 : BEQ +
         LDX.b #$02 ; Default light world theme
     +
 
     ; check if we are entering lost woods
-    LDA $8A : BEQ .endOfLightWorldChecks
+    LDA.b OverworldIndex : BEQ .endOfLightWorldChecks
 
     .notVillageOrWoods
     ; Use the normal overworld (light world) music
     LDX.b #$02
 
     ; Check phase        ; In phase >= 2
-    LDA $7EF3C5 : CMP.b #$02 : !BGE +
+    LDA.l ProgressIndicator : CMP.b #$02 : !BGE +
         ; If phase < 2, play the legend music
         LDX.b #$03
     +
 
     .endOfLightWorldChecks
     ; if we are in the light world go ahead and set chosen selection
-    LDA $7EF3CA : BEQ .lastCheck
+    LDA.l CurrentWorld : BEQ .checkInverted+4
 
-    LDX.b #$0D ; dark woods theme
+    LDX.b #$0F ; dark woods theme
 
-    ; This music is used in dark woods, and dark death mountain
-    LDA $8A
-    CMP.b #$40 : BEQ + : CMP.b #$43 : BEQ + : CMP.b #$45 : BEQ + : CMP.b #$47 : BEQ +
+    ; This music is used in dark woods
+    LDA.b OverworldIndex
+    CMP.b #$40 : BEQ +
+        LDX.b #$0D  ; dark death mountain theme
+
+    ; This music is used in dark death mountain
+    CMP.b #$43 : BEQ + : CMP.b #$45 : BEQ + : CMP.b #$47 : BEQ +
         LDX.b #$09 ; dark overworld theme
     +
 
+    ; if not inverted and light world, or inverted and dark world, skip moon pearl check
+    .checkInverted
+    LDA.l CurrentWorld : CLC : ROL #$03 : CMP.l InvertedMode : BEQ .lastCheck
+
     ; Does Link have a moon pearl?
-    LDA $7EF357 : BNE +
+    LDA.l MoonPearlEquipment : BNE +
         LDX.b #$04 ; bunny theme
     +
 
     .lastCheck
-    LDA $0132 : CMP.b #$F2 : BNE +
-    CPX $0130 : BNE +
-        ; If the last played command ($0132) was half volume (#$F2)
-        ; and the actual song playing ($0130) is same as the one for this area (X)
+    LDA.w MusicControlQueue : CMP.b #$F2 : BNE +
+    CPX.w LastAPUCommand : BNE +
+        ; If the last played command (MusicControlQueue) was half volume (#$F2)
+        ; and the actual song playing (LastAPUCommand) is same as the one for this area (X)
         ; then play the full volume command (#F3) instead of restarting the song
         LDX.b #$F3
     +
@@ -80,11 +83,186 @@ PreOverworld_LoadProperties_ChooseMusic:
 ;--------------------------------------------------------------------------------
 
 ;--------------------------------------------------------------------------------
+Overworld_FinishMirrorWarp:
+    REP #$20
+
+    LDA.w #$2641 : STA.w DMAP7
+
+    LDX.b #$3E
+
+    LDA.w #$FF00
+
+.clear_hdma_table
+
+    STA.w IrisPtr+$0000, X : STA.w IrisPtr+$0040, X
+    STA.w IrisPtr+$0080, X : STA.w IrisPtr+$00C0, X
+    STA.w IrisPtr+$0100, X : STA.w IrisPtr+$0140, X
+    STA.w IrisPtr+$0180, X
+
+    DEX #2 : BPL .clear_hdma_table
+    LDA.w #$0000 : STA.l FadeTimer : STA.l FadeDirection
+
+    SEP #$20
+    JSL $00D7C8
+    LDA.b #$80 : STA.b HDMAENQ
+    LDX.b #$04  ; bunny theme
+
+    ; if not inverted and light world, or inverted and dark world, skip moon pearl check
+    LDA.l CurrentWorld : CLC : ROL #$03 : CMP.l InvertedMode : BEQ +
+        LDA.l MoonPearlEquipment : BEQ .endOfLightWorldChecks
+    +
+
+    LDX.b #$09  ; default dark world theme
+
+    LDA.b OverworldIndex : CMP.b #$40 : !BGE .endOfLightWorldChecks
+
+    LDX.b #$02  ; hyrule field theme
+
+    ; Check if we're entering the lost woods
+    CMP.b #$00 : BNE +
+        LDA.l OverworldEventDataWRAM+$80 : AND.b #$40 : BNE .endOfLightWorldChecks
+        LDX.b #$05 ; lost woods theme
+        BRA .endOfLightWorldChecks
+    +
+
+    ; Check if we're entering the village
+    CMP.b #$18 : BNE .endOfLightWorldChecks
+
+    ; Check what phase we're in
+        LDX.b #$07 ; Default village theme (phase <3)
+
+.endOfLightWorldChecks
+    STX.w MusicControlRequest
+
+    LDA.b OverworldIndex : CMP.b #$40 : BNE +
+        LDX.b #$0F    ; dark woods theme
+        BRA .bunny
+    +
+
+    CMP.b #$43 : BEQ .darkMountain
+    CMP.b #$45 : BEQ .darkMountain
+    CMP.b #$47 : BNE .notDarkMountain
+
+.darkMountain
+    LDA.b #$09 : STA.w SFX1    ; set storm ambient SFX
+    LDX.b #$0D  ; dark mountain theme
+
+.bunny
+    LDA.l MoonPearlEquipment : ORA.l InvertedMode : BNE +
+        LDX.b #$04    ; bunny theme
+    +
+
+    STX.w MusicControlRequest
+
+.notDarkMountain
+
+    LDA.b GameSubMode : STA.w GameSubModeCache ; GameModeCache
+
+    STZ.b GameSubMode
+    STZ.b SubSubModule
+    STZ.w SubModuleInterface
+    STZ.w SkipOAM
+
+    RTL
+;--------------------------------------------------------------------------------
+
+;--------------------------------------------------------------------------------
+BirdTravel_LoadTargetAreaMusic:
+    ; Skip village and lost woods checks if entering dark world or a special area
+    LDA.b OverworldIndex : CMP.b #$43 : BEQ .endOfLightWorldChecks
+    CMP.b #$40 : !BGE .notVillageOrWoods
+
+    LDX.b #$07 ; Default village theme
+
+    ; Check if we're entering the village
+    LDA.b OverworldIndex : CMP.b #$18 : BEQ .endOfLightWorldChecks
+    ; For NA release would we also branch on indexes #$22 #$28 #$29
+
+    ; check if we are entering lost woods
+    LDA.b OverworldIndex : BEQ .endOfLightWorldChecks
+
+    .notVillageOrWoods
+    ; Use the normal overworld (light world) music
+    LDX.b #$02
+
+    ; Check phase        ; In phase >= 2
+    LDA.l ProgressIndicator : CMP.b #$02 : !BGE +
+        ; If phase < 2, play the legend music
+        LDX.b #$03
+    +
+
+    .endOfLightWorldChecks
+    ; if we are in the light world go ahead and set chosen selection
+    LDA.l CurrentWorld : BEQ .checkInverted+4
+
+    LDX.b #$09 ; dark overworld theme
+
+    LDA.b OverworldIndex
+    ; Misery Mire rain SFX
+    CMP.b #$70 : BNE ++
+        LDA.l OverworldEventDataWRAM+$70 : AND.b #$20 : BNE ++
+            LDA.b #$01 : CMP.w LastSFX1 : BEQ +
+                STA.w SFX1
+            + : BRA .checkInverted
+    ++
+
+    ; This music is used in dark death mountain
+    CMP.b #$43 : BEQ .darkMountain
+        LDA.b #$05 : STA.w SFX1
+        BRA .checkInverted
+
+.darkMountain
+    LDA.l CrystalsField : CMP.b #$7F : BEQ +
+        LDX.b #$0D  ; dark death mountain theme
+    + : LDA.b #$09 : STA.w SFX1
+
+    ; if not inverted and light world, or inverted and dark world, skip moon pearl check
+    .checkInverted
+    LDA.l CurrentWorld : CLC : ROL #$03 : CMP.l InvertedMode : BEQ .lastCheck
+
+    ; Does Link have a moon pearl?
+    LDA.l MoonPearlEquipment : BNE +
+        LDX.b #$04 ; bunny theme
+    +
+
+    .lastCheck
+    RTL
+;--------------------------------------------------------------------------------
+
+;--------------------------------------------------------------------------------
 ;0 = Is Kakariko Overworld
 ;1 = Not Kakariko Overworld
 PsychoSolder_MusicCheck:
-    LDA $040A : CMP.b #$18 : BNE .done ; thing we overwrote - check if overworld location is Kakariko
-        LDA $1B  ; Also check that we are outdoors
+    LDA.b OverworldIndex : CMP.b #$18 : BNE .done ; thing we overwrote - check if overworld location is Kakariko
+        LDA.b IndoorsFlag  ; Also check that we are outdoors
     .done
 RTL
+;--------------------------------------------------------------------------------
+
+;--------------------------------------------------------------------------------
+; Additional dark world checks to determine whether or not to fade out music
+; on mosaic transitions
+; 
+; On entry, A = $8A (overworld area being loaded)
+Overworld_MosaicDarkWorldChecks:
+    CMP.b #$40 : beq .checkCrystals
+    CMP.b #$42 : beq .checkCrystals
+    CMP.b #$50 : beq .checkCrystals
+    CMP.b #$51 : bne .doFade
+
+.checkCrystals
+    LDA.l CrystalsField : CMP.b #$7F : BEQ .done
+
+.doFade
+    LDA.b #$F1 : STA.w MusicControlRequest  ; thing we wrote over, fade out music
+
+.done
+    RTL
+;--------------------------------------------------------------------------------
+
+;--------------------------------------------------------------------------------
+; Check if the boss in ToH has been defeated (16-bit accumulator)
+CheckHeraBossDefeated:
+    LDA.l RoomDataWRAM[$07].l : AND.w #$FF00
+    RTL
 ;--------------------------------------------------------------------------------

--- a/src/z3/transition.asm
+++ b/src/z3/transition.asm
@@ -24,10 +24,6 @@ transition_to_zelda:
     lda #$8f
     sta $002100                 ; Enable PPU force blank
 
-    lda.b #$00
-    sta.w $2007
-    sta.w $2006                 ; Kill MSU-1 music if it's playing
-
     jsl zelda_spc_reset         ; Kill the SM music engine and put the SPC in IPL upload mode
                                 ; Gotta do this before switching RAM contents
 
@@ -224,6 +220,10 @@ zelda_spc_reset:
     lda #$ff                    ; Send N-SPC into "upload mode"
     sta $2140
 
+    lda.b #$00
+    sta.w $2007
+    sta.w $2006                 ; Kill MSU-1 music if it's playing
+    
     rep #$30
     lda #$0000
     sta $12


### PR DESCRIPTION
Fixes the following issues:

- The SMZ3 credits now has MSU support
- Start+Select+L+R reset now mutes the MSU immediately
- Mute MSU after the baby drains your health to match vanilla behavior
- Fixed an issue that caused SM SPC fallback code to not play the right music sometimes
- Pulled in various music fixes from ALttPR (this fixes the reported bug with mirroring from dark lost woods to lost woods playing the basic overworld theme)
- Added 10 optional extended tracks to Super Metroid
- Fixed SPC tracks resetting on certain room transitions in SM
- Prevent fading out of music when leaving the under the bridge area in Z3