### PR TITLE
Fixing SM Fallback Detection

### DIFF
--- a/src/sm/msu.asm
+++ b/src/sm/msu.asm
@@ -77,9 +77,9 @@
 ;;; * Macros *
 ;;; **********
 macro CheckMSUPresence(labelToJump)
-	lda.w !MSU_ID
-	cmp.b #'S'
-	BEQ + : jmp <labelToJump> : +
+    lda.w !MSU_ID
+    cmp.b #'S'
+    BEQ + : jmp <labelToJump> : +
 endmacro
 
 ; Init MSU and check for missing tracks
@@ -89,7 +89,7 @@ org $C08564
 ; Run SM MSU-1 code on music change
 org $C08F27
 base $808F27
-	jsr SM_MSU_Main
+    jsr SM_MSU_Main
 
 org $C0FA00
 base $80FA00
@@ -101,71 +101,71 @@ init_msu1:
     rtl
 
 SM_MSU_Main:
-	pha
-	phx
-	phy
-	php
-	phb
-	
-	sep #$30
-	
-	;; Make sure the data bank is set to $80
-	lda #$80
-	pha
-	plb
-	
-	%CheckMSUPresence(.Exit)
-	
-	;; Load current requested music
-	lda.w !RequestedMusic
-	and.b #$7F
-	bne +
-	jmp .OriginalCode
+    pha
+    phx
+    phy
+    php
+    phb
+    
+    sep #$30
+    
+    ;; Make sure the data bank is set to $80
+    lda #$80
+    pha
+    plb
+    
+    %CheckMSUPresence(.Exit)
+    
+    ;; Load current requested music
+    lda.w !RequestedMusic
+    and.b #$7F
+    bne +
+    jmp .OriginalCode
 +
 
-	;; $04 is usually ambience, call original code
-	cmp.b #$04 : BEQ .PlayAmbience
+    ;; $04 is usually ambience, call original code
+    cmp.b #$04 : BEQ .PlayAmbience
 
-	;; Check if the song is already playing
-	cmp.w !CurrentMusic
-	bne +
-	jmp .Exit
-+	
-	;; If the requested music is less than 4
-	;; it's the common music, skip to play music
-	cmp.b #$05
-	bmi .PlayMusic
-	
-	;; If requested music is greater or equal to 5
-	;; Figure out which music to play depending of
-	;; the current music bank
-	sec
-	sbc.b #$05
-	tay
-	
-	;; Load music bank and divide it by 3
-	lda.w !MusicBank
-	ldx.b #$00
-	sec
+    ;; Check if the song is already playing
+    cmp.w !CurrentMusic
+    bne +
+    jmp .Exit
++    
+    ;; If the requested music is less than 4
+    ;; it's the common music, skip to play music
+    cmp.b #$05
+    bmi .PlayMusic
+    
+    ;; If requested music is greater or equal to 5
+    ;; Figure out which music to play depending of
+    ;; the current music bank
+    sec
+    sbc.b #$05
+    tay
+    
+    ;; Load music bank and divide it by 3
+    lda.w !MusicBank
+    ldx.b #$00
+    sec
 -
-	sbc.b #$3
-	bcc +
-	inx
-	bne -
+    sbc.b #$3
+    bcc +
+    inx
+    bne -
 +
-	;; Load music mapping pointer for current bank
-	txa
-	asl
-	tax
-	rep #$20
-	lda.l MusicMappingPointers,x
-	sta.b $00
-	;; Load music to play from pointer
-	sep #$20
-	lda ($00),y
+    ;; Load music mapping pointer for current bank
+    txa
+    asl
+    tax
+    rep #$20
+    lda.l MusicMappingPointers,x
+    sta.b $00
+    ;; Load music to play from pointer
+    sep #$20
+    lda ($00),y
 
-	;; Loading $00 means calling the original code
-	bne .PlayMusic
+    ;; Loading $00 means calling the original code
+    bne .PlayMusic
     jml .OriginalCode
 
 .PlayAmbience
@@ -249,155 +249,171 @@ SM_MSU_Main:
         bra .OriginalCode
     +
     
-    phx
-    TXA : DEC : LSR #3 : TAX
-	LDA.l MSUFallbackTable+$10,X : BEQ .FailExtended : CMP.b #$FF : BEQ .continue
+    PHX
+    PHY
+    TXA
+    DEC : PHA
+        AND.b #$07 : TAY
+        PLA : LSR #3 : TAX
+    LDA.l MSUFallbackTable+$10,X : BEQ .FailExtended : CMP.b #$FF : BEQ .ContinueExtended
+
+    - : CPY #$00 : BEQ +
+        LSR : DEY : BRA -
+    +
+    
+    AND.b #$01 : BEQ .FailExtended
+
+    BRA .ContinueExtended
 
 .FailExtended
     PLA
-    TYA
+    PLY
     BRA .CheckFallbacks
 
+.ContinueExtended
+    PLY
+    BRA .continue
+
 .CheckFallbacks
-	;; Check track fallback list if the track is available
-	pha
-	DEC : PHA
-		AND.b #$07 : TAY
-		PLA : LSR #3 : TAX
-	LDA.l MSUFallbackTable+$10,X : BEQ .fallback : CMP.b #$FF : BEQ .continue
-	
-	- : CPY #$00 : BEQ +
-		LSR : DEY : BRA -
-	+
-	
-	AND.b #$01 : BEQ .fallback
+    ;; Check track fallback list if the track is available
+    pha
+    DEC : PHA
+        AND.b #$07 : TAY
+        PLA : LSR #3 : TAX
+    LDA.l MSUFallbackTable+$10,X : BEQ .fallback : CMP.b #$FF : BEQ .continue
+    
+    - : CPY #$00 : BEQ +
+        LSR : DEY : BRA -
+    +
+    
+    AND.b #$01 : BEQ .fallback
 
-	.continue
-	pla
-	tay
-	clc : adc.b #!TRACK_OFFSET
+    .continue
+    pla
+    tay
+    clc : adc.b #!TRACK_OFFSET
 
-	sta.w !MSU_AUDIO_TRACK_LO
-	stz.w !MSU_AUDIO_TRACK_HI
-	
+    sta.w !MSU_AUDIO_TRACK_LO
+    stz.w !MSU_AUDIO_TRACK_HI
+    
 .CheckAudioStatus
-	;; Play the song and add repeat if needed
-	jsr TrackNeedLooping
-	sta.w !MSU_AUDIO_CONTROL
-	
-	;; Set volume
-	lda.b #!FULL_VOLUME
-	sta.w !MSU_AUDIO_VOLUME
-	
-	;; Mute SPC music
-	lda.b #!VAL_COMMAND_MUTE_SPC	
-	- : STA.w APUIO0 : CMP.w APUIO0 : BNE - ; Wait until mute/unmute command is ACK'ed
+    ;; Play the song and add repeat if needed
+    jsr TrackNeedLooping
+    sta.w !MSU_AUDIO_CONTROL
+    
+    ;; Set volume
+    lda.b #!FULL_VOLUME
+    sta.w !MSU_AUDIO_VOLUME
+    
+    ;; Mute SPC music
+    lda.b #!VAL_COMMAND_MUTE_SPC    
+    - : STA.w APUIO0 : CMP.w APUIO0 : BNE - ; Wait until mute/unmute command is ACK'ed
     - : STZ.w APUIO0 : LDA.w APUIO0 : BNE - ; Wait until mute/unmute command is completed
-	bra .Exit
+    bra .Exit
 
 .fallback
     PLA
     BRA .OriginalCode
 
 .OriginalCode
-	lda.b #$00
-	sta.w !MSU_AUDIO_CONTROL
-	sta.w !MSU_AUDIO_VOLUME
+    lda.b #$00
+    sta.w !MSU_AUDIO_CONTROL
+    sta.w !MSU_AUDIO_VOLUME
 
-	;; Unmute SPC music
-	lda.b #!VAL_COMMAND_UNMUTE_SPC	
-	- : STA.w APUIO0 : CMP.w APUIO0 : BNE - ; Wait until mute/unmute command is ACK'ed
+    ;; Unmute SPC music
+    lda.b #!VAL_COMMAND_UNMUTE_SPC    
+    - : STA.w APUIO0 : CMP.w APUIO0 : BNE - ; Wait until mute/unmute command is ACK'ed
     - : STZ.w APUIO0 : LDA.w APUIO0 : BNE - ; Wait until mute/unmute command is completed
 
 .Exit
-	plb
-	plp
-	ply
-	plx
-	pla
+    plb
+    plp
+    ply
+    plx
+    pla
 
-	sta.w !SPC_COMM_0
-	rts
-	
+    sta.w !SPC_COMM_0
+    rts
+    
 MusicMappingPointers:
-	dw bank_00
-	dw bank_03
-	dw bank_06
-	dw bank_09
-	dw bank_0C
-	dw bank_0F
-	dw bank_12
-	dw bank_15
-	dw bank_18
-	dw bank_1B
-	dw bank_1E
-	dw bank_21
-	dw bank_24
-	dw bank_27
-	dw bank_2A
-	dw bank_2D
-	dw bank_30
-	dw bank_33
-	dw bank_36
-	dw bank_39
-	dw bank_3C
-	dw bank_3F
-	dw bank_42
-	dw bank_45
-	dw bank_48
+    dw bank_00
+    dw bank_03
+    dw bank_06
+    dw bank_09
+    dw bank_0C
+    dw bank_0F
+    dw bank_12
+    dw bank_15
+    dw bank_18
+    dw bank_1B
+    dw bank_1E
+    dw bank_21
+    dw bank_24
+    dw bank_27
+    dw bank_2A
+    dw bank_2D
+    dw bank_30
+    dw bank_33
+    dw bank_36
+    dw bank_39
+    dw bank_3C
+    dw bank_3F
+    dw bank_42
+    dw bank_45
+    dw bank_48
 
 MusicMapping:
 ;; 00 means use SPC music
 bank_00: ;; Opening
-	db 04,05
+    db 04,05
 bank_03: ;; Opening
-	db 04,05
+    db 04,05
 bank_06: ;; Crateria (First Landing)
-	db 06,00,07
+    db 06,00,07
 bank_09: ;; Crateria
-	db 08,09
+    db 08,09
 bank_0C: ;; Samus's Ship
-	db 10
+    db 10
 bank_0F: ;; Brinstar with vegatation
-	db 11
+    db 11
 bank_12: ;; Brinstar Red Soil
-	db 12
+    db 12
 bank_15: ;; Upper Norfair
-	db 13
+    db 13
 bank_18: ;; Lower Norfair
-	db 14
+    db 14
 bank_1B: ;; Maridia
-	db 15,16
+    db 15,16
 bank_1E: ;; Tourian
-	db 17,00
+    db 17,00
 bank_21: ;; Mother Brain Battle
-	db 18
+    db 18
 bank_24: ;; Big Boss Battle 1 (3rd is with alarm)
-	db 19,21,20
+    db 19,21,20
 bank_27: ;; Big Boss Battle 2
-	db 22,23
+    db 22,23
 bank_2A: ;; Plant Miniboss
-	db 24
+    db 24
 bank_2D: ;; Ceres Station
-	db 00,25,00
+    db 00,25,00
 bank_30: ;; Wrecked Ship
-	db 26,27
+    db 26,27
 bank_33: ;; Ambience SFX
-	db 00,00,00
+    db 00,00,00
 bank_36: ;; Theme of Super Metroid
-	db 28
+    db 28
 bank_39: ;; Death Cry
-	db 29
+    db 29
 bank_3C: ;; Ending
-	db 30
+    db 30
 bank_3F: ;; "The Last Metroid"
-	db 00
+    db 00
 bank_42: ;; "is at peace"
-	db 00
+    db 00
 bank_45: ;; Big Boss Battle 2
-	db 22,23
+    db 22,23
 bank_48: ;; Samus's Ship (Mother Brain)
-	db 10
+    db 10
 
 BossTwoExtendedThemes:
 db #00,#32,#00,#34,#00,#38 ; Boss theme two
@@ -407,20 +423,20 @@ db #00,#31,#00,#33,#00,#37 ; Boss theme two
 
 TrackNeedLooping:
 ;; Samus Aran's Appearance fanfare
-	cpy.b #01
-	beq NoLooping
+    cpy.b #01
+    beq NoLooping
 ;; Item acquisition fanfare
-	cpy.b #02
-	beq NoLooping
+    cpy.b #02
+    beq NoLooping
 ;; Death fanfare
-	cpy.b #29
-	beq NoLooping
+    cpy.b #29
+    beq NoLooping
 ;; Ending
-	cpy.b #30
-	beq NoLooping
+    cpy.b #30
+    beq NoLooping
 
-	lda.b #$03
-	rts
+    lda.b #$03
+    rts
 NoLooping:
-	lda.b #$01
-	rts
+    lda.b #$01
+    rts


### PR DESCRIPTION
My previous fallback code was pretty broken. For the extended tracks, for each group of 8 songs, if any of those 8 songs were missing, none of the extended tracks would play and it would go to the fallback for all of them.

For extended tracks 31 & 32, this would include missing tracks like 25 (Ceres Station) and 28 (Theme of Super Metroid), both of which are not played in SMZ3. For MSUs that had all tracks 25+, it would work just fine. For MSUs that were missing all extended tracks, it would work just fine as well. This issue just cropped up on MSUs that were missing some tracks.

I also noticed that the file was 50/50 tabs and spaces, so I updated to all spaces.