### PR TITLE
Msu updates

### DIFF
--- a/src/credits.asm
+++ b/src/credits.asm
@@ -83,7 +83,7 @@ init:
     ; If MSU music is previously playing, play the combo credits MSU track
     sep #$30
     lda $2002 : cmp.b #'S' : bne +
-        lda #99 : sta $2004 : stz $2005 ; Play track 99
+        lda #99 : sta $0332 : sta $2004 : stz $2005 ; Play track 99
         lda #1 : sta $2007 ; Sets the track to not repeat
         lda #$FF : sta $2006 ; Set to max volume
     + 

--- a/src/credits.asm
+++ b/src/credits.asm
@@ -77,24 +77,24 @@ init:
     lda #$0000
     tcd
 
-    ; Check if MSU-1 is available
-    lda.w $2002 : cmp.w #$2D53 : bne .playspc
-
     ; Play MSU-1 track 99 if available
     sep #$30
-    lda.b #99 : sta.w $0332 : sta.w $2004 : stz.w $2005
-    - lda.w $2000 : bit.b #$40 : bne -          ; Wait for MSU-1 BUSY
-    lda.w $2000 : bit.b #$08 : bne .fallback    ; Check MSU-1 Track missing otherwise fall back to SPC
-    lda.b #1 : sta.w $2007                      ; Sets the track to not repeat
-    lda.b #$FF : sta.w $2006                    ; Set to max volume
-    bra .load_graphics
+    lda $2002 : cmp.b #'S' : bne +
+        lda.b #99 : sta $0332 : sta.w $2004 : stz.w $2005
+        - lda.w $2000 : bit.b #$40 : bne -          ; Wait for MSU-1 BUSY
+        lda.w $2000 : bit.b #$08 : bne .fallback    ; Check MSU-1 Track missing otherwise fall back to SPC
+        lda.b #1 : sta.w $2007                      ; Sets the track to not repeat
+        lda.b #$FF : sta.w $2006                    ; Set to max volume
+    +
+    bra .play_music
 
 .fallback
     ; Mute any currently playing MSU-1 track
+    stz $0332
     stz.w $2007 : stz.w $2006
     stz.w $2004 : stz.w $2005
 
-.playspc
+.play_music
     ; Start SPC song
     jsl playmusic
 

--- a/src/credits.asm
+++ b/src/credits.asm
@@ -80,6 +80,7 @@ init:
     ; Play MSU-1 track 99 if available
     sep #$30
     lda $2002 : cmp.b #'S' : bne +
+        stz.w $2006                                 ; Mute before waiting while MSU-1 is busy
         lda.b #99 : sta $0332 : sta.w $2004 : stz.w $2005
         - lda.w $2000 : bit.b #$40 : bne -          ; Wait for MSU-1 BUSY
         lda.w $2000 : bit.b #$08 : bne .fallback    ; Check MSU-1 Track missing otherwise fall back to SPC

--- a/src/sm/msu.asm
+++ b/src/sm/msu.asm
@@ -332,6 +332,7 @@ SM_MSU_Main:
     sta.w !CURRENT_MSU_TRACK
     sta.w !MSU_AUDIO_TRACK_LO
     stz.w !MSU_AUDIO_TRACK_HI
+    stz.w !MSU_AUDIO_VOLUME
     
 .CheckAudioStatus
     lda.w !MSU_STATUS : bit.b #!MSU_STATUS_AUDIO_BUSY : bne .CheckAudioStatus

--- a/src/sm/msu.asm
+++ b/src/sm/msu.asm
@@ -51,6 +51,7 @@
 !MSU_AUDIO_TRACK_HI = $2005
 !MSU_AUDIO_VOLUME = $2006
 !MSU_AUDIO_CONTROL = $2007
+!CURRENT_MSU_TRACK = $0332
 
 ;;; SPC communication ports
 !SPC_COMM_0 = $2140
@@ -293,6 +294,7 @@ SM_MSU_Main:
     tay
     clc : adc.b #!TRACK_OFFSET
 
+    sta.w !CURRENT_MSU_TRACK
     sta.w !MSU_AUDIO_TRACK_LO
     stz.w !MSU_AUDIO_TRACK_HI
     

--- a/src/sm/msu.asm
+++ b/src/sm/msu.asm
@@ -83,6 +83,11 @@ macro CheckMSUPresence(labelToJump)
     BEQ + : jmp <labelToJump> : +
 endmacro
 
+; Hijack SM reset code to mute msu
+org $C08462
+base $808462
+    jml debug_reset_mute_msu
+
 ; Init MSU and check for missing tracks
 org $C08564
     jsl init_msu1
@@ -92,8 +97,8 @@ org $C08F27
 base $808F27
     jsr SM_MSU_Main
 
-org $C0FA00
-base $80FA00
+org $C0F900
+base $80F900
 init_msu1:
     jsl MSUInit
 
@@ -442,3 +447,13 @@ TrackNeedLooping:
 NoLooping:
     lda.b #$01
     rts
+
+debug_reset_mute_msu:
+    sep #$30
+    lda.b #$00
+    sta.w $2004
+    sta.w $2005
+    REP #$30
+    LDX #$1FFF
+    TCD
+    JML $80846E

--- a/src/spc_play.asm
+++ b/src/spc_play.asm
@@ -92,17 +92,23 @@ loadspc:
 
     ; Copy $02-ef to SPC RAM
     ; sendmusicblock $e0 $c002 $0002 $00ee
-    sep #!A_8BIT
-    lda #$f6    ; 1
-    sta $14
-    rep #!A_8BIT
-    lda #$0002  ; 2
-    sta $12
+    ; Only begin playing if there is no MSU track playing
+    sep #$30
+    lda $0332 : cmp.b #99 : beq +
+        rep #$30
+        sep #!A_8BIT
+        lda #$f6    ; 1
+        sta $14
+        rep #!A_8BIT
+        lda #$0002  ; 2
+        sta $12
 
+        rep #!XY_8BIT
+        ldx #$0002 ; 3
+        ldy #$00ee ; 4
+        jsr copyblocktospc
+    +
     rep #!XY_8BIT
-    ldx #$0002 ; 3
-    ldy #$00ee ; 4
-    jsr copyblocktospc
 
     ; sendmusicblock $f6 $0100 $0100 $7f00
     sep #!A_8BIT
@@ -118,17 +124,22 @@ loadspc:
     jsr copyblocktospc
 
     ; sendmusicblock $f7 $0000 $8000 $7fc0
-    sep #!A_8BIT
-    lda #$f7 ; 1
-    sta $14
-    rep #!A_8BIT
-    lda #$0000 ; 2
-    sta $12
+    ; Only begin playing if there is no MSU track playing
+    sep #$30
+    lda $0332 : cmp.b #99 : beq +
+        rep #$30
+        sep #!A_8BIT
+        lda #$f7 ; 1
+        sta $14
+        rep #!A_8BIT
+        lda #$0000 ; 2
+        sta $12
 
-    rep #!XY_8BIT
-    ldx #$8000 ; 3
-    ldy #$7fc0 ; 4
-    jsr copyblocktospc
+        rep #!XY_8BIT
+        ldx #$8000 ; 3
+        ldy #$7fc0 ; 4
+        jsr copyblocktospc
+    +
 
     ; Create SPC init code that sets up registers
     jsr makespcinitcode


### PR DESCRIPTION
This PR makes two changes:

- It saves the current playing SM track to 7e0332. From my digging, it appears this memory address is currently unused in SM, and I don't see any of the SMZ3 code using it. https://jathys.zophar.net/supermetroid/kejardon/RAMMap.txt This has been in the SMZ3 Cas' fork for a while with no issues. The purpose of this is to be able to use the MSU Randomizer to read the current playing track.
- There was an issue where pressing L+R+Start+Select didn't reset the music when pressing it in SM. This would cause the music to continue playing for a second until the title screen music started to kick in.
- Fixes credits music not working in BSNES
- Fixes stutter sound that would happen when switching tracks in Super Metroid on the fxpakpro